### PR TITLE
Add support for go1.x lambda runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.x
+* Add support for go1.x lambda runtime
+* Fix support for deploying lambda via S3 bucket
+
 # v0.1.2
 * Fix property namespaces, function/handler, and include role (#2)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ source files contained within configured directories.
  * Acceptable functions will be defined inline
  * S3 storage will be used when inline is unacceptable
  * S3 versioning will be used when bucket configured for versioning
- * Automatic asset builds (for `java8` runtime targets)
+ * Automatic asset builds (for `java8` and `go1.x` runtime targets)
 
 ## Usage
 
@@ -44,14 +44,18 @@ Configuration.new do
 end
 ```
 
-_NOTE: If using the `java8` runtime for lambda functions, `maven` must
-be installed with `mvn` being available within the user's PATH._
+_NOTE:_ 
+  * If using the `java8` runtime for lambda functions, `maven` must 
+    be installed with `mvn` being available within the user's PATH.
+  * If using the `go1.x` runtime for lambda functions, `golang` and 
+    `zip` utility must be installed with `go` and `zip` being available 
+    within the user's PATH.
 
 ### Configuration
 
 #### Lambda function files directory
 
-By default the `sfn-lambda` callback will search the `./lambda` directory
+By default, the `sfn-lambda` callback will search the `./lambda` directory
 for lambda function files. A custom directory path can be used by modifying
 the configuration:
 
@@ -65,7 +69,7 @@ end
 
 #### S3 lambda function file storage
 
-By default the `sfn-lambda` callback will use the bucket name provided by
+By default, the `sfn-lambda` callback will use the bucket name provided by
 the `nesting_bucket` configuration item. This can be customized to use a
 different bucket by modifying the configuration:
 
@@ -89,13 +93,9 @@ identifier to reference the function. The path structure is as follows:
 ./lambda/RUNTIME/FUNCTION_NAME.extension
 ```
 
-The `RUNTIME` defines the runtime used for handling the lambda function. At
-the time of writing this, that value can be one of:
-
-* `nodejs`
-* `nodejs4.3`
-* `java8`
-* `python2.7`
+The `RUNTIME` defines the runtime used for handling the lambda function.
+Please check https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html 
+for the full list.
 
 _NOTE: Runtime values are not validated which allows new runtimes to be used
 as they are made available._

--- a/lib/sfn-lambda/control.rb
+++ b/lib/sfn-lambda/control.rb
@@ -99,10 +99,10 @@ module SfnLambda
         io.close
 
         version = nil
-        unless(versioning_enabled?)
+        if(versioning_enabled?)
           s3 = callback.api.connection.api_for(:storage)
           result = s3.request(
-            :path => s3.file_path(file),
+            :path => s3.file_path(file.name),
             :endpoint => s3.bucket_endpoint(file.bucket),
             :method => :head
           )
@@ -158,7 +158,7 @@ module SfnLambda
 
     # @return [TrueClass, FalseClass] bucket has versioning enabled
     def versioning_enabled?
-      unless(@versioned.nil?)
+      if(@versioned.nil?)
         s3 = callback.api.connection.api_for(:storage)
         result = s3.request(
           :path => '/',

--- a/lib/sfn-lambda/inject.rb
+++ b/lib/sfn-lambda/inject.rb
@@ -28,11 +28,11 @@ class SparkleFormation
         new_fn.properties.handler fn_handler
         new_fn.properties.runtime lookup[:runtime]
         new_fn.properties.function_name fn_function_name || fn_name
+        new_fn.properties.role fn_role
         content = ::SfnLambda.control.format_content(lookup)
         if(content[:raw])
           new_fn.properties.code.zip_file content[:raw]
           new_fn.properties.handler "index.#{fn_handler}"
-          new_fn.properties.role fn_role
         else
           new_fn.properties.code.s3_bucket content[:bucket]
           new_fn.properties.code.s3_key content[:key]


### PR DESCRIPTION
Hello folks. We needed to have support for go1.x lambda functions in SparkleFormation and these were the fixes needed to have that possible. I tried to update the Changelog which show the best what was added and fixed.

Fixes #9 

